### PR TITLE
Fixed Last Weapon Swapping, implemented Melee Weapon Swapping, Implemented Weapon Stowing

### DIFF
--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -207,7 +207,7 @@ export class Player extends GameObject {
     ];
 
     selectedWeaponSlot = 2;
-    lastWeaponSlot = 2;
+    lastWeaponSlot = this.selectedWeaponSlot;
 
     actionItem: {
         typeString: string
@@ -481,8 +481,14 @@ export class Player extends GameObject {
         const primary = deepCopy(this.weapons[0]);
         this.weapons[0] = deepCopy(this.weapons[1]);
         this.weapons[1] = primary;
+
+        var lastWep = this.lastWeaponSlot;
         if(this.selectedWeaponSlot === 0) this.switchSlot(1);
         else if(this.selectedWeaponSlot === 1) this.switchSlot(0);
+        else this.switchSlot(this.selectedWeaponSlot);
+        if (lastWep === 0) lastWep = 1;
+        else if (lastWep === 1) lastWep = 0;
+        this.lastWeaponSlot = lastWep;
     }
 
     weaponCooldownOver(): boolean {

--- a/src/packets/receiving/inputPacket.ts
+++ b/src/packets/receiving/inputPacket.ts
@@ -105,6 +105,9 @@ export class InputPacket extends ReceivingPacket {
                 case InputType.Cancel:
                     p.cancelAction();
                     break;
+                case InputType.StowWeapons:
+                    p.switchSlot(2);
+                    break;
             }
         }
 


### PR DESCRIPTION
Implemented weapon stowing to switch from a weapon to melee.
Implemented weapon swapping when melee weapon is currently selected.
Fixed Last Weapon Swapping, the original surviv.io does not set the last weapon to the other weapon after swapping, it only changes weapon inventory positions. Fixed Last Weapon Swapping works with the implemented weapon swapping with melee.