### PR TITLE
FixedKill Leader Logic, Implemented Equip Next and Prev Scope

### DIFF
--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -645,7 +645,7 @@ export class Game {
 
     assignKillLeader(p: Player): void {
         this.killLeaderDirty = true;
-        if(this.killLeader !== p) { // If the player isn't already the Kill Leader...
+        if(this.killLeader !== p || !p.dead) { // If the player isn't already the Kill Leader... //And isn't dead
             p.role = TypeToId.kill_leader;
             this.killLeader = p;
             this.roleAnnouncements.push(new RoleAnnouncementPacket(p, true, false));

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -340,7 +340,18 @@ export class Player extends GameObject {
         this.zoomDirty = true;
     }
 
-    setScope(scope: string): void {
+    setScope(scope: string, skipScope?: boolean): void {
+        if(this.scope.typeString !== scope && skipScope && scope) {
+            let direction = ScopeTypes.indexOf(scope) > ScopeTypes.indexOf(this.scope.typeString) ? 1 : -1;
+            
+            while(!this.inventory[scope]) {
+                let newScope = ScopeTypes[clamp(ScopeTypes.indexOf(scope) + direction, 0, ScopeTypes.length-1)];
+                if (newScope === scope)
+                    break;
+                scope = newScope;
+            }
+        }
+        
         if(!this.inventory[scope]) return;
 
         this.scope.typeString = scope;

--- a/src/packets/receiving/inputPacket.ts
+++ b/src/packets/receiving/inputPacket.ts
@@ -98,6 +98,14 @@ export class InputPacket extends ReceivingPacket {
                 case InputType.EquipLastWeap:
                     p.switchSlot(p.lastWeaponSlot);
                     break;
+                    
+                case InputType.EquipNextScope:
+                    p.setScope(ScopeTypes[ScopeTypes.indexOf(p.scope.typeString) + 1], true);
+                    break;
+
+                case InputType.EquipPrevScope:
+                    p.setScope(ScopeTypes[ScopeTypes.indexOf(p.scope.typeString) - 1], true);
+                    break;
 
                 case InputType.Reload:
                     p.reload();


### PR DESCRIPTION
Fixed Kill Leader Logic, if a kill leader shoots a bullet before they die killing another person and still has the most kills, they are reassigned as the kill leader despite being dead, the fix verifies if they are not dead.

Implemented Equip Next and Prev Scope inputs and functionality.