### PR TITLE
Fixing two game-breaking bugs

### DIFF
--- a/src/game/bullet.ts
+++ b/src/game/bullet.ts
@@ -75,6 +75,7 @@ export class Bullet {
             position,
             fixedRotation: true
         });
+        this.body.setBullet(true);
         this.body.createFixture({
             shape: Circle(0),
             friction: 0.0,

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -589,7 +589,7 @@ export class Player extends GameObject {
             const angle = unitVecToRadians(this.direction) + randomFloat(-spread, spread);
             const bullet: Bullet = new Bullet(
                 this,
-                Vec2(this.position.x + weapon.barrelLength * Math.cos(angle), this.position.y + weapon.barrelLength * Math.sin(angle)),
+                Vec2(this.position.x + 1.5 * Math.cos(angle), this.position.y + 1.5 * Math.sin(angle)),
                 Vec2(Math.cos(angle), Math.sin(angle)),
                 weapon.bulletType,
                 this.activeWeapon.typeId,


### PR DESCRIPTION
Fixed the shooting-through-walls exploit by making bullets spawn at the player instead of at the tip of the gun.
Fixed bullets inconsistently colliding by enabled bullet(high-speed-body) physics on them.
