### PR TITLE
Fixing issues with ammo after dropping weapons

### DIFF
--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -396,8 +396,8 @@ export class Player extends GameObject {
         if(this.weapons[slot].typeString === item) { // Only drop the gun if it's the same as the one we have, AND it's in the selected slot
             if(this.activeWeapon.ammo > 0) {
                 // Put the ammo in the gun back in the inventory
-                const ammoType: string = this.activeWeaponInfo.ammo;
-                (this.inventory[ammoType] as number) += (this.activeWeapon.ammo as number); // TODO Make this.inventory a Map to prevent this mess
+                const ammoType: string = Weapons[this.weapons[slot].typeString].ammo;
+                (this.inventory[ammoType] as number) += (this.weapons[slot].ammo as number); // TODO Make this.inventory a Map to prevent this mess
 
                 // If the new amount is more than the inventory can hold, drop the extra
                 const overAmount: number = this.inventory[ammoType] - Constants.bagSizes[ammoType][this.backpackLevel];

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -394,7 +394,7 @@ export class Player extends GameObject {
         if(this.weapons[slot].typeId === 0) return;
         // For guns
         if(this.weapons[slot].typeString === item) { // Only drop the gun if it's the same as the one we have, AND it's in the selected slot
-            if(this.activeWeapon.ammo > 0) {
+            if(this.weapons[slot].ammo as number > 0) {
                 // Put the ammo in the gun back in the inventory
                 const ammoType: string = Weapons[this.weapons[slot].typeString].ammo;
                 (this.inventory[ammoType] as number) += (this.weapons[slot].ammo as number); // TODO Make this.inventory a Map to prevent this mess


### PR DESCRIPTION
 Fixed ammo dupe glitch. Previously, dropping a gun would add [to the dropper's inventory] the ammo of the active weapon - it now adds the ammo of the dropped weapon.

Fixed bug where dropping a weapon while holding your melee weapon would not give you ammo held in that weapon back.