### PR TITLE
Implement Dual-Wielded Guns and Improved Shooting Mechanics

### DIFF
--- a/data/weapons.json
+++ b/data/weapons.json
@@ -2774,7 +2774,7 @@
     "dualOffset": 0.6,
     "recoilTime": 10000000000,
     "moveSpread": 9,
-    "shotSpread": 0,
+    "shotSpread": 11,
     "bulletCount": 1,
     "bulletType": "bullet_m9",
     "bulletTypeBonus": "bullet_m9_bonus",

--- a/src/game/objects/loot.ts
+++ b/src/game/objects/loot.ts
@@ -127,12 +127,14 @@ export class Loot extends GameObject {
             // if it is a gun
             const canDualWield = !!Weapons[this.typeString]?.dualWieldType;
             if(canDualWield && p.weapons[0].typeId === this.typeId) {
-                p.weapons[0].typeString = Weapons[this.typeString]?.dualWieldType;
-                p.weapons[0].typeId = this.typeId + 1;
+                const gunTypeString = Weapons[this.typeString]?.dualWieldType;
+                p.weapons[0].typeString = gunTypeString;
+                p.weapons[0].typeId = TypeToId[gunTypeString];
                 slotSwitchingTo = 0;
             } else if (canDualWield && p.weapons[1].typeId === this.typeId) {
-                p.weapons[1].typeString = Weapons[this.typeString]?.dualWieldType;
-                p.weapons[1].typeId = this.typeId + 1;
+                const gunTypeString = Weapons[this.typeString]?.dualWieldType;
+                p.weapons[1].typeString = gunTypeString;
+                p.weapons[1].typeId = TypeToId[gunTypeString];
                 slotSwitchingTo = 1;
             } else if (p.weapons[0].typeId === 0) {
                 p.weapons[0].typeString = this.typeString;

--- a/src/game/objects/loot.ts
+++ b/src/game/objects/loot.ts
@@ -125,7 +125,16 @@ export class Loot extends GameObject {
         } else {
             let slotSwitchingTo: number;
             // if it is a gun
-            if(p.weapons[0].typeId === 0) {
+            const canDualWield = !!Weapons[this.typeString]?.dualWieldType;
+            if(canDualWield && p.weapons[0].typeId === this.typeId) {
+                p.weapons[0].typeString = Weapons[this.typeString]?.dualWieldType;
+                p.weapons[0].typeId = this.typeId + 1;
+                slotSwitchingTo = 0;
+            } else if (canDualWield && p.weapons[1].typeId === this.typeId) {
+                p.weapons[1].typeString = Weapons[this.typeString]?.dualWieldType;
+                p.weapons[1].typeId = this.typeId + 1;
+                slotSwitchingTo = 1;
+            } else if (p.weapons[0].typeId === 0) {
                 p.weapons[0].typeString = this.typeString;
                 p.weapons[0].typeId = this.typeId;
                 slotSwitchingTo = 0;

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -400,6 +400,7 @@ export class Player extends GameObject {
         if(this.weapons[slot].typeId === 0) return;
         // For guns
         if(this.weapons[slot].typeString === item) { // Only drop the gun if it's the same as the one we have, AND it's in the selected slot
+            const isDualWielded = this.weapons[slot].typeString.endsWith("dual");
             if(this.weapons[slot].ammo as number > 0) {
                 // Put the ammo in the gun back in the inventory
                 const ammoType: string = Weapons[this.weapons[slot].typeString].ammo;
@@ -439,9 +440,22 @@ export class Player extends GameObject {
             if(this.selectedWeaponSlot === slot && !skipItemSwitch) this.switchSlot(2);
             this.cancelAction();
             this.weaponsDirty = true;
-            const loot = new Loot(this.game, item, this.position, this.layer, 1);
-            this.game.dynamicObjects.add(loot);
-            this.game.fullDirtyObjects.add(loot);
+            if(isDualWielded) {
+                const singleGun = item.substring(0, item.lastIndexOf("_"));
+                // TODO: Adjust gun positions to reduce overlap.
+                const loot = [
+                    new Loot(this.game, singleGun, this.position, this.layer, 1),
+                    new Loot(this.game, singleGun, this.position, this.layer, 1)
+                ];
+                for(const gun of loot) {
+                    this.game.dynamicObjects.add(gun);
+                    this.game.fullDirtyObjects.add(gun);
+                }
+            } else {
+                const loot = new Loot(this.game, item, this.position, this.layer, 1);
+                this.game.dynamicObjects.add(loot);
+                this.game.fullDirtyObjects.add(loot);
+            }
             this.game.updateObjects = true;
         }
         // For individual items

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -222,6 +222,8 @@ export class Player extends GameObject {
     actionType = 0;
     actionSeq = 0;
 
+    lastShotHand: "right" | "left" = "right";
+
     speed = Config.movementSpeed;
     diagonalSpeed = Config.diagonalSpeed;
 
@@ -343,7 +345,7 @@ export class Player extends GameObject {
         this.zoomDirty = true;
     }
 
-    spawnBullet(): void {
+    spawnBullet(offset = 0): void {
         let shotFx = true;
         const weapon = Weapons[this.activeWeapon.typeString];
         const spread = degreesToRadians(weapon.shotSpread);
@@ -351,7 +353,8 @@ export class Player extends GameObject {
             const angle = unitVecToRadians(this.direction) + randomFloat(-spread, spread);
             const bullet: Bullet = new Bullet(
               this,
-              Vec2(this.position.x + 1.5 * Math.cos(angle), this.position.y + 1.5 * Math.sin(angle)),
+            //   Vec2(this.position.x + 1.5 * Math.cos(angle), this.position.y + 1.5 * Math.sin(angle)),
+              Vec2(this.position.x + (offset * Math.cos(angle + Math.PI / 2)) + 1.5 * Math.cos(angle), this.position.y + (offset * Math.sin(angle + Math.PI / 2)) + 1.5 * Math.sin(angle)),
               Vec2(Math.cos(angle), Math.sin(angle)),
               weapon.bulletType,
               this.activeWeapon.typeId,
@@ -639,7 +642,11 @@ export class Player extends GameObject {
         }
         for(let i = 0; i < burstCount; i++) {
             this.weaponsDirty = true;
-            setTimeout(() => this.spawnBullet(), 1000 * i * burstDelay);
+            setTimeout(() => {
+                // Get the dual offset of the weapon based on the current shooting hand.
+                const offset = (weapon.dualOffset * (this.lastShotHand === "right" ? 1 : -1)) || 0;
+                this.spawnBullet(offset);
+            }, 1000 * i * burstDelay);
             this.activeWeapon.ammo--;
             if(this.activeWeapon.ammo < 0) this.activeWeapon.ammo = 0;
             if(this.activeWeapon.ammo === 0) {
@@ -648,6 +655,12 @@ export class Player extends GameObject {
                 return;
             }
         }
+
+        if(weapon.isDual) {
+            if(this.lastShotHand === "right") this.lastShotHand = "left";
+            else this.lastShotHand = "right";
+        }
+
         //moved bullet spawning to its own function to clean up burst logic
         /*
         for(let i = 0; i < weapon.bulletCount; i++) {


### PR DESCRIPTION
- Dual wielded guns now drop as separate items.
- Implemented dual-wielding: if a gun can be dual wielded, picking up a second gun of the same type will turn them into a dual-wielded weapon.
- Implemented shooting from each hand instead of the center for dual-wielded weapons.