### PR TITLE
Bug fix for healing items not canceling when dropping items

### DIFF
--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -497,6 +497,8 @@ export class Player extends GameObject {
             const isHelmet = item.startsWith("helmet");
             const isVest = item.startsWith("chest");
 
+            this.cancelAction();
+
             if(isHelmet || isVest) {
                 if(isHelmet) {
                     const level = this.helmetLevel;


### PR DESCRIPTION
Fixed bug where you cannot cancel healing or use soda/pills when you drop items like ammo, scopes, helmets, vests, and other healing items.