### PR TITLE
Use items while reloading fix & adjust amount of loot dropped each drop

### DIFF
--- a/src/game/objects/loot.ts
+++ b/src/game/objects/loot.ts
@@ -270,10 +270,10 @@ export function generateLooseLootFromArray(game: Game, loot: looseLootTiers[], p
 }
 export function splitUpLoot(player: Player, item: string, amount: number): Loot[] {
     const loot: Loot[] = [];
-    const dropCount = Math.floor(amount / 30);
+    const dropCount = Math.floor(amount / 60);
     for(let i = 0; i < dropCount; i++) {
-        loot.push(new Loot(player.game, item, player.position, player.layer, 30));
+        loot.push(new Loot(player.game, item, player.position, player.layer, 60));
     }
-    if(amount % 30 !== 0) loot.push(new Loot(player.game, item, player.position, player.layer, amount % 30));
+    if(amount % 60 !== 0) loot.push(new Loot(player.game, item, player.position, player.layer, amount % 60));
     return loot;
 }

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -717,21 +717,25 @@ export class Player extends GameObject {
 
     useBandage(): void {
         if(this.health === 100 || this.inventory.bandage === 0) return;
+        this.cancelAction();
         this.doAction("bandage", 3);
     }
 
     useMedkit(): void {
         if(this.health === 100 || this.inventory.healthkit === 0) return;
+        this.cancelAction();
         this.doAction("healthkit", 6);
     }
 
     useSoda(): void {
         if(this.boost === 100 || this.inventory.soda === 0) return;
+        this.cancelAction();
         this.doAction("soda", 3);
     }
 
     usePills(): void {
         if(this.boost === 100 || this.inventory.painkiller === 0) return;
+        this.cancelAction();
         this.doAction("painkiller", 5);
     }
 

--- a/src/game/objects/player.ts
+++ b/src/game/objects/player.ts
@@ -558,11 +558,17 @@ export class Player extends GameObject {
                 }
 
                 let amountToDrop = Math.floor(inventoryCount / 2);
-                if(isMed && inventoryCount <= 3) amountToDrop = Math.ceil(inventoryCount / 2);
 
                 amountToDrop = Math.max(1, amountToDrop);
-                if(amountToDrop < 5 && isAmmo) amountToDrop = Math.min(5, inventoryCount);
-
+                if(inventoryCount <= 15 && isAmmo && item === "9mm") {
+                    amountToDrop = Math.min(15, inventoryCount);
+                } else if(inventoryCount <= 10 && isAmmo && item === "762mm" || item === "556mm") {
+                    amountToDrop = Math.min(10, inventoryCount);
+                } else if(inventoryCount <= 5 && isAmmo && item === "12gauge") {
+                    amountToDrop = Math.min(5, inventoryCount);
+                } else if(inventoryCount <= 5 && isAmmo) {
+                    amountToDrop = Math.min(5, inventoryCount);
+                }
                 this.inventory[item] = inventoryCount - amountToDrop;
 
                 this.inventoryDirty = true;


### PR DESCRIPTION
Fixed a bug where you cannot use healing/adrenaline items while reloading (reloading circle still appears while healing though)

Adjusted amount of items dropped for each drop to be a little less to be more like the original surviv.io, especially ammo