### PR TITLE
Added Loot Under Berry Bush

### DIFF
--- a/data/lootTables.json
+++ b/data/lootTables.json
@@ -218,4 +218,5 @@
     "4xscope": { "count": 1, "weight": 1 },
     "8xscope": { "count": 1, "weight": 0.35 },
     "15xscope": { "count": 1, "weight": 0.0001 }
+  }
 }

--- a/data/lootTables.json
+++ b/data/lootTables.json
@@ -208,5 +208,14 @@
     "m249": { "count": 1, "weight": 0.1 },
     "pkp": { "count": 1, "weight": 0.05 },
     "m9": { "count": 1, "weight": 0.01 }
-  }
+  },
+  "tier_berry": {
+    "9mm": { "count": 60, "weight": 3 },
+    "762mm": { "count": 60, "weight": 3 },
+    "12gauge": { "count": 10, "weight": 3 },
+    "556mm": { "count": 60, "weight": 3 },
+    "2xscope": { "count": 1, "weight": 4 },
+    "4xscope": { "count": 1, "weight": 1 },
+    "8xscope": { "count": 1, "weight": 0.35 },
+    "15xscope": { "count": 1, "weight": 0.0001 }
 }

--- a/data/objects.json
+++ b/data/objects.json
@@ -1703,7 +1703,15 @@
     "terrain": {
       "grass": true,
       "beach": false
-    }
+    },
+     "loot": [
+      {
+        "tier": "tier_berry",
+        "min": 1,
+        "max": 1,
+        "props": {}
+      }
+    ],
   },
   "bush_rose": {
     "type": "obstacle",


### PR DESCRIPTION
I added the loot under the berry bush, with the in-game id of "bush_07". If there is already a loot table, just change it in objects.json, it's around line 1650.