### PR TITLE
Added Already Equipped message for melee weapons and made other fixes related to picking them up

### DIFF
--- a/src/game/objects/loot.ts
+++ b/src/game/objects/loot.ts
@@ -126,12 +126,22 @@ export class Loot extends GameObject {
             // Reload active gun if the player picks up the correct ammo
             if(p.activeWeapon.ammo === 0 && this.typeString === p.activeWeaponInfo.ammo) p.reload();
         } else if(Weapons[this.typeString]?.type === "melee") {
-            if(p.weapons[2].typeString !== "fists") { // TODO Do item type check in drop item packet, not in drop item method
+            let slotSwitchingTo: number | undefined;
+            if(p.weapons[2].typeString === this.typeString) {
+                result = PickupMsgType.AlreadyEquipped;
+            } else if(p.weapons[2].typeString !== "fists") { // TODO Do item type check in drop item packet, not in drop item method
                 p.dropItemInSlot(2, p.weapons[2].typeString, true);
+                slotSwitchingTo = 2;
             }
             p.weapons[2].typeString = this.typeString;
             p.weapons[2].typeId = this.typeId;
-            p.switchSlot(2);
+            if(slotSwitchingTo === undefined) {
+                slotSwitchingTo = p.selectedWeaponSlot === 2 ? 2 : undefined;
+            }
+            if(slotSwitchingTo !== undefined) {
+                p.switchSlot(slotSwitchingTo);
+            }
+            p.weaponsDirty = true;
         } else {
             let slotSwitchingTo: number;
             // if it is a gun


### PR DESCRIPTION
Implemented the Already Equipped message when you try to pick up a melee weapon that you already have.
Also fixed issues related to this like guns reloading when you try to pick up a melee weapon that you already have and you switching to the melee weapon after picking it up when your active weapon is a gun.